### PR TITLE
Make color.Color use f32 for each color component

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           version: master
       - name: Run tests
-        run: zig build test -Drelease-fast
+        run: zig build test

--- a/src/format_interface.zig
+++ b/src/format_interface.zig
@@ -9,5 +9,5 @@ pub const FormatInterface = struct {
 
     pub const FormatFn = fn () image.ImageFormat;
     pub const FormatDetectFn = fn (inStream: *image.ImageInStream, seekStream: *image.ImageSeekStream) anyerror!bool;
-    pub const ReadForImageFn = fn (allocator: *Allocator, inStream: *image.ImageInStream, seekStream: *image.ImageSeekStream) anyerror!image.ImageInfo;
+    pub const ReadForImageFn = fn (allocator: *Allocator, inStream: *image.ImageInStream, seekStream: *image.ImageSeekStream, pixels: *?color.ColorStorage) anyerror!image.ImageInfo;
 };

--- a/src/image.zig
+++ b/src/image.zig
@@ -22,7 +22,9 @@ pub const ImageInStream = io.InStream(anyerror);
 pub const ImageSeekStream = io.SeekableStream(anyerror, anyerror);
 
 pub const ImageInfo = struct {
-    width: usize = 0, height: usize = 0, pixels: ?ColorStorage = null, pixel_format: PixelFormat = undefined
+    width: usize = 0,
+    height: usize = 0,
+    pixel_format: PixelFormat = undefined,
 };
 
 /// Format-independant image
@@ -109,12 +111,12 @@ pub const Image = struct {
         self.image_format = formatInterface.format();
 
         try seekStream.seekTo(0);
-        const imageInfo = try formatInterface.readForImage(allocator, inStream, seekStream);
+
+        const imageInfo = try formatInterface.readForImage(allocator, inStream, seekStream, &self.pixels);
 
         self.width = imageInfo.width;
         self.height = imageInfo.height;
         self.pixel_format = imageInfo.pixel_format;
-        self.pixels = imageInfo.pixels;
     }
 
     fn findImageInterface(inStream: *ImageInStream, seekStream: *ImageSeekStream) !FormatInterface {

--- a/src/octree_quantizer.zig
+++ b/src/octree_quantizer.zig
@@ -1,7 +1,7 @@
 const Allocator = @import("std").mem.Allocator;
 const ArenaAllocator = @import("std").heap.ArenaAllocator;
 const ArrayList = @import("std").ArrayList;
-const Color = @import("color.zig").Color;
+const IntegerColor8 = @import("color.zig").IntegerColor8;
 
 const MaxDepth = 8;
 
@@ -43,15 +43,15 @@ pub const OctTreeQuantizer = struct {
         try self.levels[@intCast(usize, level)].append(node);
     }
 
-    pub fn addColor(self: *Self, color: Color) !void {
+    pub fn addColor(self: *Self, color: IntegerColor8) !void {
         try self.rootNode.addColor(color, 0, self);
     }
 
-    pub fn getPaletteIndex(self: Self, color: Color) !usize {
+    pub fn getPaletteIndex(self: Self, color: IntegerColor8) !usize {
         return try self.rootNode.getPaletteIndex(color, 0);
     }
 
-    pub fn makePalette(self: *Self, colorCount: usize, palette: []Color) anyerror![]Color {
+    pub fn makePalette(self: *Self, colorCount: usize, palette: []IntegerColor8) anyerror![]IntegerColor8 {
         var paletteIndex: usize = 0;
 
         var rootLeafNodes = try self.rootNode.getLeafNodes(self.arenaAllocator.child_allocator);
@@ -122,11 +122,11 @@ const OctTreeQuantizerNode = struct {
         return self.referenceCount > 0;
     }
 
-    pub fn getColor(self: Self) Color {
-        return Color.initRGB(@intCast(u8, self.red / self.referenceCount), @intCast(u8, self.green / self.referenceCount), @intCast(u8, self.blue / self.referenceCount));
+    pub fn getColor(self: Self) IntegerColor8 {
+        return IntegerColor8.initRGB(@intCast(u8, self.red / self.referenceCount), @intCast(u8, self.green / self.referenceCount), @intCast(u8, self.blue / self.referenceCount));
     }
 
-    pub fn addColor(self: *Self, color: Color, level: i32, parent: *OctTreeQuantizer) anyerror!void {
+    pub fn addColor(self: *Self, color: IntegerColor8, level: i32, parent: *OctTreeQuantizer) anyerror!void {
         if (level >= MaxDepth) {
             self.red += color.R;
             self.green += color.G;
@@ -148,7 +148,7 @@ const OctTreeQuantizerNode = struct {
         }
     }
 
-    pub fn getPaletteIndex(self: Self, color: Color, level: i32) anyerror!usize {
+    pub fn getPaletteIndex(self: Self, color: IntegerColor8, level: i32) anyerror!usize {
         if (self.isLeaf()) {
             return self.paletteIndex;
         }
@@ -201,7 +201,7 @@ const OctTreeQuantizerNode = struct {
         return result - 1;
     }
 
-    inline fn getColorIndex(color: Color, level: i32) usize {
+    inline fn getColorIndex(color: IntegerColor8, level: i32) usize {
         var index: usize = 0;
         var mask = @intCast(u8, 0b10000000) >> @intCast(u3, level);
         if (color.R & mask != 0) {

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -4,18 +4,18 @@ const color = @import("zigimg").color;
 usingnamespace @import("helpers.zig");
 
 test "Convert color to premultipled alpha" {
-    const originalColor = color.Color.initRGBA(100, 128, 210, 100);
+    const originalColor = color.Color.initRGBA(100 / 255, 128 / 255, 210 / 255, 100 / 255);
     const premultipliedAlpha = originalColor.premultipliedAlpha();
 
-    expectEq(premultipliedAlpha.R, 39);
-    expectEq(premultipliedAlpha.G, 50);
-    expectEq(premultipliedAlpha.B, 82);
-    expectEq(premultipliedAlpha.A, 100);
+    expectEq(premultipliedAlpha.R, 39 / 255);
+    expectEq(premultipliedAlpha.G, 50 / 255);
+    expectEq(premultipliedAlpha.B, 82 / 255);
+    expectEq(premultipliedAlpha.A, 100 / 255);
 }
 
 test "Convert Rgb24 to Color" {
     const originalColor = color.Rgb24.initRGB(100, 128, 210);
-    const result = originalColor.toColor();
+    const result = originalColor.toColor().toIntegerColor8();
 
     expectEq(result.R, 100);
     expectEq(result.G, 128);
@@ -25,7 +25,7 @@ test "Convert Rgb24 to Color" {
 
 test "Convert Rgba32 to Color" {
     const originalColor = color.Rgba32.initRGBA(1, 2, 3, 4);
-    const result = originalColor.toColor();
+    const result = originalColor.toColor().toIntegerColor8();
 
     expectEq(result.R, 1);
     expectEq(result.G, 2);
@@ -35,7 +35,7 @@ test "Convert Rgba32 to Color" {
 
 test "Convert Rgb565 to Color" {
     const originalColor = color.Rgb565.initRGB(10, 30, 20);
-    const result = originalColor.toColor();
+    const result = originalColor.toColor().toIntegerColor8();
 
     expectEq(result.R, 82);
     expectEq(result.G, 121);
@@ -45,7 +45,7 @@ test "Convert Rgb565 to Color" {
 
 test "Convert Rgb555 to Color" {
     const originalColor = color.Rgb555.initRGB(16, 20, 24);
-    const result = originalColor.toColor();
+    const result = originalColor.toColor().toIntegerColor8();
 
     expectEq(result.R, 132);
     expectEq(result.G, 165);
@@ -55,7 +55,7 @@ test "Convert Rgb555 to Color" {
 
 test "Convert Argb32 to Color" {
     const originalColor = color.Argb32.initRGBA(50, 100, 150, 200);
-    const result = originalColor.toColor();
+    const result = originalColor.toColor().toIntegerColor8();
 
     expectEq(result.R, 50);
     expectEq(result.G, 100);
@@ -64,16 +64,16 @@ test "Convert Argb32 to Color" {
 }
 
 test "Convert Monochrome to Color" {
-    const white = color.Monochrome { .value = 1 };
-    const whiteColor = white.toColor();
+    const white = color.Monochrome{ .value = 1 };
+    const whiteColor = white.toColor().toIntegerColor8();
 
     expectEq(whiteColor.R, 255);
     expectEq(whiteColor.G, 255);
     expectEq(whiteColor.B, 255);
     expectEq(whiteColor.A, 255);
 
-    const black = color.Monochrome { .value = 0 };
-    const blackColor = black.toColor();
+    const black = color.Monochrome{ .value = 0 };
+    const blackColor = black.toColor().toIntegerColor8();
 
     expectEq(blackColor.R, 0);
     expectEq(blackColor.G, 0);
@@ -82,8 +82,8 @@ test "Convert Monochrome to Color" {
 }
 
 test "Convert Grayscale8 to Color" {
-    const original = color.Grayscale8 { .value = 128 };
-    const result = original.toColor();
+    const original = color.Grayscale8{ .value = 128 };
+    const result = original.toColor().toIntegerColor8();
 
     expectEq(result.R, 128);
     expectEq(result.G, 128);
@@ -92,8 +92,8 @@ test "Convert Grayscale8 to Color" {
 }
 
 test "Convert Grayscale16 to Color" {
-    const original = color.Grayscale16 { .value = 21845 };
-    const result = original.toColor();
+    const original = color.Grayscale16{ .value = 21845 };
+    const result = original.toColor().toIntegerColor8();
 
     expectEq(result.R, 85);
     expectEq(result.G, 85);

--- a/tests/helpers.zig
+++ b/tests/helpers.zig
@@ -1,6 +1,12 @@
 const std = @import("std");
 const testing = std.testing;
 
+pub const zigimg_test_allocator = &zigimg_test_allocator_instance.allocator;
+pub var zigimg_test_allocator_instance = testing.LeakCountAllocator.init(&zigimg_base_allocator_instance.allocator);
+
+pub var zigimg_base_allocator_instance = std.heap.ThreadSafeFixedBufferAllocator.init(zigimg_allocator_mem[0..]);
+var zigimg_allocator_mem: [4 * 1024 * 1024]u8 = undefined;
+
 pub fn expectEq(actual: var, expected: var) void {
     testing.expectEqual(@as(@TypeOf(actual), expected), actual);
 }

--- a/tests/image_test.zig
+++ b/tests/image_test.zig
@@ -6,7 +6,7 @@ const PixelFormat = @import("zigimg").PixelFormat;
 usingnamespace @import("helpers.zig");
 
 test "Create Image Bpp1" {
-    const image = try Image.create(testing.allocator, 24, 32, PixelFormat.Bpp1);
+    const image = try Image.create(zigimg_test_allocator, 24, 32, PixelFormat.Bpp1);
     defer image.deinit();
 
     expectEq(image.width, 24);
@@ -22,7 +22,7 @@ test "Create Image Bpp1" {
 }
 
 test "Create Image Bpp2" {
-    const image = try Image.create(testing.allocator, 24, 32, PixelFormat.Bpp2);
+    const image = try Image.create(zigimg_test_allocator, 24, 32, PixelFormat.Bpp2);
     defer image.deinit();
 
     expectEq(image.width, 24);
@@ -38,7 +38,7 @@ test "Create Image Bpp2" {
 }
 
 test "Create Image Bpp4" {
-    const image = try Image.create(testing.allocator, 24, 32, PixelFormat.Bpp4);
+    const image = try Image.create(zigimg_test_allocator, 24, 32, PixelFormat.Bpp4);
     defer image.deinit();
 
     expectEq(image.width, 24);
@@ -54,7 +54,7 @@ test "Create Image Bpp4" {
 }
 
 test "Create Image Bpp8" {
-    const image = try Image.create(testing.allocator, 24, 32, PixelFormat.Bpp8);
+    const image = try Image.create(zigimg_test_allocator, 24, 32, PixelFormat.Bpp8);
     defer image.deinit();
 
     expectEq(image.width, 24);
@@ -70,7 +70,7 @@ test "Create Image Bpp8" {
 }
 
 test "Create Image Bpp16" {
-    const image = try Image.create(testing.allocator, 24, 32, PixelFormat.Bpp16);
+    const image = try Image.create(zigimg_test_allocator, 24, 32, PixelFormat.Bpp16);
     defer image.deinit();
 
     expectEq(image.width, 24);
@@ -86,7 +86,7 @@ test "Create Image Bpp16" {
 }
 
 test "Create Image Rgb24" {
-    const image = try Image.create(testing.allocator, 24, 32, PixelFormat.Rgb24);
+    const image = try Image.create(zigimg_test_allocator, 24, 32, PixelFormat.Rgb24);
     defer image.deinit();
 
     expectEq(image.width, 24);
@@ -101,7 +101,7 @@ test "Create Image Rgb24" {
 }
 
 test "Create Image Rgba32" {
-    const image = try Image.create(testing.allocator, 24, 32, PixelFormat.Rgba32);
+    const image = try Image.create(zigimg_test_allocator, 24, 32, PixelFormat.Rgba32);
     defer image.deinit();
 
     expectEq(image.width, 24);
@@ -116,7 +116,7 @@ test "Create Image Rgba32" {
 }
 
 test "Create Image Rgb565" {
-    const image = try Image.create(testing.allocator, 24, 32, PixelFormat.Rgb565);
+    const image = try Image.create(zigimg_test_allocator, 24, 32, PixelFormat.Rgb565);
     defer image.deinit();
 
     expectEq(image.width, 24);
@@ -131,7 +131,7 @@ test "Create Image Rgb565" {
 }
 
 test "Create Image Rgb555" {
-    const image = try Image.create(testing.allocator, 24, 32, PixelFormat.Rgb555);
+    const image = try Image.create(zigimg_test_allocator, 24, 32, PixelFormat.Rgb555);
     defer image.deinit();
 
     expectEq(image.width, 24);
@@ -146,7 +146,7 @@ test "Create Image Rgb555" {
 }
 
 test "Create Image Argb32" {
-    const image = try Image.create(testing.allocator, 24, 32, PixelFormat.Argb32);
+    const image = try Image.create(zigimg_test_allocator, 24, 32, PixelFormat.Argb32);
     defer image.deinit();
 
     expectEq(image.width, 24);
@@ -169,7 +169,7 @@ test "Should detect BMP properly" {
     };
 
     for (imageTests) |image_path| {
-        const image = try Image.fromFilePath(testing.allocator, image_path);
+        const image = try Image.fromFilePath(zigimg_test_allocator, image_path);
         defer image.deinit();
         testing.expect(image.image_format == .Bmp);
     }
@@ -184,7 +184,7 @@ test "Should detect PCX properly" {
     };
 
     for (imageTests) |image_path| {
-        const image = try Image.fromFilePath(testing.allocator, image_path);
+        const image = try Image.fromFilePath(zigimg_test_allocator, image_path);
         defer image.deinit();
         testing.expect(image.image_format == .Pcx);
     }
@@ -197,7 +197,7 @@ test "Should detect PBM properly" {
     };
 
     for (imageTests) |image_path| {
-        const image = try Image.fromFilePath(testing.allocator, image_path);
+        const image = try Image.fromFilePath(zigimg_test_allocator, image_path);
         defer image.deinit();
         testing.expect(image.image_format == .Pbm);
     }
@@ -212,7 +212,7 @@ test "Should detect PGM properly" {
     };
 
     for (imageTests) |image_path| {
-        const image = try Image.fromFilePath(testing.allocator, image_path);
+        const image = try Image.fromFilePath(zigimg_test_allocator, image_path);
         defer image.deinit();
         testing.expect(image.image_format == .Pgm);
     }
@@ -225,24 +225,24 @@ test "Should detect PPM properly" {
     };
 
     for (imageTests) |image_path| {
-        const image = try Image.fromFilePath(testing.allocator, image_path);
+        const image = try Image.fromFilePath(zigimg_test_allocator, image_path);
         defer image.deinit();
         testing.expect(image.image_format == .Ppm);
     }
 }
 
 test "Should error on invalid path" {
-    var invalidPath = Image.fromFilePath(testing.allocator, "notapathdummy");
+    var invalidPath = Image.fromFilePath(zigimg_test_allocator, "notapathdummy");
     expectError(invalidPath, error.FileNotFound);
 }
 
 test "Should error on invalid file" {
-    var invalidFile = Image.fromFilePath(testing.allocator, "tests/helpers.zig");
+    var invalidFile = Image.fromFilePath(zigimg_test_allocator, "tests/helpers.zig");
     expectError(invalidFile, error.ImageFormatInvalid);
 }
 
 test "Should read a 24-bit bitmap" {
-    var image = try Image.fromFilePath(testing.allocator, "tests/fixtures/bmp/simple_v4.bmp");
+    var image = try Image.fromFilePath(zigimg_test_allocator, "tests/fixtures/bmp/simple_v4.bmp");
     defer image.deinit();
 
     expectEq(image.width, 8);
@@ -294,18 +294,18 @@ test "Should read a 24-bit bitmap" {
 }
 
 test "Test Color iterator" {
-    var image = try Image.fromFilePath(testing.allocator, "tests/fixtures/bmp/simple_v4.bmp");
+    var image = try Image.fromFilePath(zigimg_test_allocator, "tests/fixtures/bmp/simple_v4.bmp");
     defer image.deinit();
 
     const expectedColors = [_]color.Color{
-        color.Color.initRGB(0xFF, 0x00, 0x00),
-        color.Color.initRGB(0x00, 0xFF, 0x00),
-        color.Color.initRGB(0x00, 0x00, 0xFF),
-        color.Color.initRGB(0x00, 0xFF, 0xFF),
-        color.Color.initRGB(0xFF, 0x00, 0xFF),
-        color.Color.initRGB(0xFF, 0xFF, 0x00),
-        color.Color.initRGB(0x00, 0x00, 0x00),
-        color.Color.initRGB(0xFF, 0xFF, 0xFF),
+        color.Color.initRGB(1.0, 0.0, 0.0),
+        color.Color.initRGB(0.0, 1.0, 0.0),
+        color.Color.initRGB(0.0, 0.0, 1.0),
+        color.Color.initRGB(0.0, 1.0, 1.0),
+        color.Color.initRGB(1.0, 0.0, 1.0),
+        color.Color.initRGB(1.0, 1.0, 0.0),
+        color.Color.initRGB(0.0, 0.0, 0.0),
+        color.Color.initRGB(1.0, 1.0, 1.0),
     };
 
     expectEq(image.width, 8);

--- a/tests/netpbm_test.zig
+++ b/tests/netpbm_test.zig
@@ -11,209 +11,297 @@ const zigimg = @import("zigimg");
 usingnamespace @import("helpers.zig");
 
 test "Load ASCII PBM image" {
-    const file = try testOpenFile(testing.allocator, "tests/fixtures/netpbm/pbm_ascii.pbm");
+    const file = try testOpenFile(zigimg_test_allocator, "tests/fixtures/netpbm/pbm_ascii.pbm");
     defer file.close();
 
     var fileInStream = file.inStream();
     var fileSeekStream = file.seekableStream();
 
     var pbmFile = netpbm.PBM{};
-    const pixels = try pbmFile.read(testing.allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream));
-    defer pixels.deinit(testing.allocator);
+
+    var pixelsOpt: ?color.ColorStorage = null;
+    try pbmFile.read(zigimg_test_allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream), &pixelsOpt);
+
+    defer {
+        if (pixelsOpt) |pixels| {
+            pixels.deinit(zigimg_test_allocator);
+        }
+    }
 
     expectEq(pbmFile.header.width, 8);
     expectEq(pbmFile.header.height, 16);
     expectEq(pbmFile.pixel_format, PixelFormat.Monochrome);
 
-    testing.expect(pixels == .Monochrome);
+    testing.expect(pixelsOpt != null);
 
-    expectEq(pixels.Monochrome[0].value, 0);
-    expectEq(pixels.Monochrome[1].value, 1);
-    expectEq(pixels.Monochrome[15 * 8 + 7].value, 1);
+    if (pixelsOpt) |pixels| {
+        testing.expect(pixels == .Monochrome);
+
+        expectEq(pixels.Monochrome[0].value, 0);
+        expectEq(pixels.Monochrome[1].value, 1);
+        expectEq(pixels.Monochrome[15 * 8 + 7].value, 1);
+    }
 }
 
 test "Load binary PBM image" {
-    const file = try testOpenFile(testing.allocator, "tests/fixtures/netpbm/pbm_binary.pbm");
+    const file = try testOpenFile(zigimg_test_allocator, "tests/fixtures/netpbm/pbm_binary.pbm");
     defer file.close();
 
     var fileInStream = file.inStream();
     var fileSeekStream = file.seekableStream();
 
     var pbmFile = netpbm.PBM{};
-    const pixels = try pbmFile.read(testing.allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream));
-    defer pixels.deinit(testing.allocator);
+
+    var pixelsOpt: ?color.ColorStorage = null;
+    try pbmFile.read(zigimg_test_allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream), &pixelsOpt);
+
+    defer {
+        if (pixelsOpt) |pixels| {
+            pixels.deinit(zigimg_test_allocator);
+        }
+    }
 
     expectEq(pbmFile.header.width, 8);
     expectEq(pbmFile.header.height, 16);
     expectEq(pbmFile.pixel_format, PixelFormat.Monochrome);
 
-    testing.expect(pixels == .Monochrome);
+    testing.expect(pixelsOpt != null);
 
-    expectEq(pixels.Monochrome[0].value, 0);
-    expectEq(pixels.Monochrome[1].value, 1);
-    expectEq(pixels.Monochrome[15 * 8 + 7].value, 1);
+    if (pixelsOpt) |pixels| {
+        testing.expect(pixels == .Monochrome);
+
+        expectEq(pixels.Monochrome[0].value, 0);
+        expectEq(pixels.Monochrome[1].value, 1);
+        expectEq(pixels.Monochrome[15 * 8 + 7].value, 1);
+    }
 }
 
 test "Load ASCII PGM 8-bit grayscale image" {
-    const file = try testOpenFile(testing.allocator, "tests/fixtures/netpbm/pgm_ascii_grayscale8.pgm");
+    const file = try testOpenFile(zigimg_test_allocator, "tests/fixtures/netpbm/pgm_ascii_grayscale8.pgm");
     defer file.close();
 
     var fileInStream = file.inStream();
     var fileSeekStream = file.seekableStream();
 
     var pgmFile = netpbm.PGM{};
-    const pixels = try pgmFile.read(testing.allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream));
-    defer pixels.deinit(testing.allocator);
+
+    var pixelsOpt: ?color.ColorStorage = null;
+    try pgmFile.read(zigimg_test_allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream), &pixelsOpt);
+
+    defer {
+        if (pixelsOpt) |pixels| {
+            pixels.deinit(zigimg_test_allocator);
+        }
+    }
 
     expectEq(pgmFile.header.width, 16);
     expectEq(pgmFile.header.height, 24);
     expectEq(pgmFile.pixel_format, PixelFormat.Grayscale8);
 
-    testing.expect(pixels == .Grayscale8);
+    testing.expect(pixelsOpt != null);
 
-    expectEq(pixels.Grayscale8[0].value, 2);
-    expectEq(pixels.Grayscale8[1].value, 5);
-    expectEq(pixels.Grayscale8[383].value, 196);
+    if (pixelsOpt) |pixels| {
+        testing.expect(pixels == .Grayscale8);
+
+        expectEq(pixels.Grayscale8[0].value, 2);
+        expectEq(pixels.Grayscale8[1].value, 5);
+        expectEq(pixels.Grayscale8[383].value, 196);
+    }
 }
 
 test "Load Binary PGM 8-bit grayscale image" {
-    const file = try testOpenFile(testing.allocator, "tests/fixtures/netpbm/pgm_binary_grayscale8.pgm");
+    const file = try testOpenFile(zigimg_test_allocator, "tests/fixtures/netpbm/pgm_binary_grayscale8.pgm");
     defer file.close();
 
     var fileInStream = file.inStream();
     var fileSeekStream = file.seekableStream();
 
     var pgmFile = netpbm.PGM{};
-    const pixels = try pgmFile.read(testing.allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream));
-    defer pixels.deinit(testing.allocator);
+
+    var pixelsOpt: ?color.ColorStorage = null;
+    try pgmFile.read(zigimg_test_allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream), &pixelsOpt);
+
+    defer {
+        if (pixelsOpt) |pixels| {
+            pixels.deinit(zigimg_test_allocator);
+        }
+    }
 
     expectEq(pgmFile.header.width, 16);
     expectEq(pgmFile.header.height, 24);
     expectEq(pgmFile.pixel_format, PixelFormat.Grayscale8);
 
-    testing.expect(pixels == .Grayscale8);
+    testing.expect(pixelsOpt != null);
 
-    expectEq(pixels.Grayscale8[0].value, 2);
-    expectEq(pixels.Grayscale8[1].value, 5);
-    expectEq(pixels.Grayscale8[383].value, 196);
+    if (pixelsOpt) |pixels| {
+        testing.expect(pixels == .Grayscale8);
+
+        expectEq(pixels.Grayscale8[0].value, 2);
+        expectEq(pixels.Grayscale8[1].value, 5);
+        expectEq(pixels.Grayscale8[383].value, 196);
+    }
 }
 
 test "Load ASCII PGM 16-bit grayscale image" {
-    const file = try testOpenFile(testing.allocator, "tests/fixtures/netpbm/pgm_ascii_grayscale16.pgm");
+    const file = try testOpenFile(zigimg_test_allocator, "tests/fixtures/netpbm/pgm_ascii_grayscale16.pgm");
     defer file.close();
 
     var fileInStream = file.inStream();
     var fileSeekStream = file.seekableStream();
 
     var pgmFile = netpbm.PGM{};
-    const pixels = try pgmFile.read(testing.allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream));
-    defer pixels.deinit(testing.allocator);
+
+    var pixelsOpt: ?color.ColorStorage = null;
+    try pgmFile.read(zigimg_test_allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream), &pixelsOpt);
+
+    defer {
+        if (pixelsOpt) |pixels| {
+            pixels.deinit(zigimg_test_allocator);
+        }
+    }
 
     expectEq(pgmFile.header.width, 8);
     expectEq(pgmFile.header.height, 16);
     expectEq(pgmFile.pixel_format, PixelFormat.Grayscale8);
 
-    testing.expect(pixels == .Grayscale8);
+    testing.expect(pixelsOpt != null);
 
-    expectEq(pixels.Grayscale8[0].value, 13);
-    expectEq(pixels.Grayscale8[1].value, 16);
-    expectEq(pixels.Grayscale8[127].value, 237);
+    if (pixelsOpt) |pixels| {
+        testing.expect(pixels == .Grayscale8);
+
+        expectEq(pixels.Grayscale8[0].value, 13);
+        expectEq(pixels.Grayscale8[1].value, 16);
+        expectEq(pixels.Grayscale8[127].value, 237);
+    }
 }
 
 test "Load Binary PGM 16-bit grayscale image" {
-    const file = try testOpenFile(testing.allocator, "tests/fixtures/netpbm/pgm_binary_grayscale16.pgm");
+    const file = try testOpenFile(zigimg_test_allocator, "tests/fixtures/netpbm/pgm_binary_grayscale16.pgm");
     defer file.close();
 
     var fileInStream = file.inStream();
     var fileSeekStream = file.seekableStream();
 
     var pgmFile = netpbm.PGM{};
-    const pixels = try pgmFile.read(testing.allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream));
-    defer pixels.deinit(testing.allocator);
+
+    var pixelsOpt: ?color.ColorStorage = null;
+    try pgmFile.read(zigimg_test_allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream), &pixelsOpt);
+
+    defer {
+        if (pixelsOpt) |pixels| {
+            pixels.deinit(zigimg_test_allocator);
+        }
+    }
 
     expectEq(pgmFile.header.width, 8);
     expectEq(pgmFile.header.height, 16);
     expectEq(pgmFile.pixel_format, PixelFormat.Grayscale8);
 
-    testing.expect(pixels == .Grayscale8);
+    testing.expect(pixelsOpt != null);
 
-    expectEq(pixels.Grayscale8[0].value, 13);
-    expectEq(pixels.Grayscale8[1].value, 16);
-    expectEq(pixels.Grayscale8[127].value, 237);
+    if (pixelsOpt) |pixels| {
+        testing.expect(pixels == .Grayscale8);
+
+        expectEq(pixels.Grayscale8[0].value, 13);
+        expectEq(pixels.Grayscale8[1].value, 16);
+        expectEq(pixels.Grayscale8[127].value, 237);
+    }
 }
 
 test "Load ASCII PPM image" {
-    const file = try testOpenFile(testing.allocator, "tests/fixtures/netpbm/ppm_ascii_rgb24.ppm");
+    const file = try testOpenFile(zigimg_test_allocator, "tests/fixtures/netpbm/ppm_ascii_rgb24.ppm");
     defer file.close();
 
     var fileInStream = file.inStream();
     var fileSeekStream = file.seekableStream();
 
     var ppmFile = netpbm.PPM{};
-    const pixels = try ppmFile.read(testing.allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream));
-    defer pixels.deinit(testing.allocator);
+
+    var pixelsOpt: ?color.ColorStorage = null;
+    try ppmFile.read(zigimg_test_allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream), &pixelsOpt);
+
+    defer {
+        if (pixelsOpt) |pixels| {
+            pixels.deinit(zigimg_test_allocator);
+        }
+    }
 
     expectEq(ppmFile.header.width, 27);
     expectEq(ppmFile.header.height, 27);
     expectEq(ppmFile.pixel_format, PixelFormat.Rgb24);
 
-    testing.expect(pixels == .Rgb24);
+    testing.expect(pixelsOpt != null);
 
-    expectEq(pixels.Rgb24[0].R, 0x34);
-    expectEq(pixels.Rgb24[0].G, 0x53);
-    expectEq(pixels.Rgb24[0].B, 0x9f);
+    if (pixelsOpt) |pixels| {
+        testing.expect(pixels == .Rgb24);
 
-    expectEq(pixels.Rgb24[1].R, 0x32);
-    expectEq(pixels.Rgb24[1].G, 0x5b);
-    expectEq(pixels.Rgb24[1].B, 0x96);
+        expectEq(pixels.Rgb24[0].R, 0x34);
+        expectEq(pixels.Rgb24[0].G, 0x53);
+        expectEq(pixels.Rgb24[0].B, 0x9f);
 
-    expectEq(pixels.Rgb24[26].R, 0xa8);
-    expectEq(pixels.Rgb24[26].G, 0x5a);
-    expectEq(pixels.Rgb24[26].B, 0x78);
+        expectEq(pixels.Rgb24[1].R, 0x32);
+        expectEq(pixels.Rgb24[1].G, 0x5b);
+        expectEq(pixels.Rgb24[1].B, 0x96);
 
-    expectEq(pixels.Rgb24[27].R, 0x2e);
-    expectEq(pixels.Rgb24[27].G, 0x54);
-    expectEq(pixels.Rgb24[27].B, 0x99);
+        expectEq(pixels.Rgb24[26].R, 0xa8);
+        expectEq(pixels.Rgb24[26].G, 0x5a);
+        expectEq(pixels.Rgb24[26].B, 0x78);
 
-    expectEq(pixels.Rgb24[26 * 27 + 26].R, 0x88);
-    expectEq(pixels.Rgb24[26 * 27 + 26].G, 0xb7);
-    expectEq(pixels.Rgb24[26 * 27 + 26].B, 0x55);
+        expectEq(pixels.Rgb24[27].R, 0x2e);
+        expectEq(pixels.Rgb24[27].G, 0x54);
+        expectEq(pixels.Rgb24[27].B, 0x99);
+
+        expectEq(pixels.Rgb24[26 * 27 + 26].R, 0x88);
+        expectEq(pixels.Rgb24[26 * 27 + 26].G, 0xb7);
+        expectEq(pixels.Rgb24[26 * 27 + 26].B, 0x55);
+    }
 }
 
 test "Load binary PPM image" {
-    const file = try testOpenFile(testing.allocator, "tests/fixtures/netpbm/ppm_binary_rgb24.ppm");
+    const file = try testOpenFile(zigimg_test_allocator, "tests/fixtures/netpbm/ppm_binary_rgb24.ppm");
     defer file.close();
 
     var fileInStream = file.inStream();
     var fileSeekStream = file.seekableStream();
 
     var ppmFile = netpbm.PPM{};
-    const pixels = try ppmFile.read(testing.allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream));
-    defer pixels.deinit(testing.allocator);
+
+    var pixelsOpt: ?color.ColorStorage = null;
+    try ppmFile.read(zigimg_test_allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream), &pixelsOpt);
+
+    defer {
+        if (pixelsOpt) |pixels| {
+            pixels.deinit(zigimg_test_allocator);
+        }
+    }
 
     expectEq(ppmFile.header.width, 27);
     expectEq(ppmFile.header.height, 27);
     expectEq(ppmFile.pixel_format, PixelFormat.Rgb24);
 
-    testing.expect(pixels == .Rgb24);
+    testing.expect(pixelsOpt != null);
 
-    expectEq(pixels.Rgb24[0].R, 0x34);
-    expectEq(pixels.Rgb24[0].G, 0x53);
-    expectEq(pixels.Rgb24[0].B, 0x9f);
+    if (pixelsOpt) |pixels| {
+        testing.expect(pixels == .Rgb24);
 
-    expectEq(pixels.Rgb24[1].R, 0x32);
-    expectEq(pixels.Rgb24[1].G, 0x5b);
-    expectEq(pixels.Rgb24[1].B, 0x96);
+        expectEq(pixels.Rgb24[0].R, 0x34);
+        expectEq(pixels.Rgb24[0].G, 0x53);
+        expectEq(pixels.Rgb24[0].B, 0x9f);
 
-    expectEq(pixels.Rgb24[26].R, 0xa8);
-    expectEq(pixels.Rgb24[26].G, 0x5a);
-    expectEq(pixels.Rgb24[26].B, 0x78);
+        expectEq(pixels.Rgb24[1].R, 0x32);
+        expectEq(pixels.Rgb24[1].G, 0x5b);
+        expectEq(pixels.Rgb24[1].B, 0x96);
 
-    expectEq(pixels.Rgb24[27].R, 0x2e);
-    expectEq(pixels.Rgb24[27].G, 0x54);
-    expectEq(pixels.Rgb24[27].B, 0x99);
+        expectEq(pixels.Rgb24[26].R, 0xa8);
+        expectEq(pixels.Rgb24[26].G, 0x5a);
+        expectEq(pixels.Rgb24[26].B, 0x78);
 
-    expectEq(pixels.Rgb24[26 * 27 + 26].R, 0x88);
-    expectEq(pixels.Rgb24[26 * 27 + 26].G, 0xb7);
-    expectEq(pixels.Rgb24[26 * 27 + 26].B, 0x55);
+        expectEq(pixels.Rgb24[27].R, 0x2e);
+        expectEq(pixels.Rgb24[27].G, 0x54);
+        expectEq(pixels.Rgb24[27].B, 0x99);
+
+        expectEq(pixels.Rgb24[26 * 27 + 26].R, 0x88);
+        expectEq(pixels.Rgb24[26 * 27 + 26].G, 0xb7);
+        expectEq(pixels.Rgb24[26 * 27 + 26].B, 0x55);
+    }
 }

--- a/tests/pcx_test.zig
+++ b/tests/pcx_test.zig
@@ -11,116 +11,170 @@ const zigimg = @import("zigimg");
 usingnamespace @import("helpers.zig");
 
 test "PCX bpp1 (linear)" {
-    const file = try testOpenFile(testing.allocator, "tests/fixtures/pcx/test-bpp1.pcx");
+    const file = try testOpenFile(zigimg_test_allocator, "tests/fixtures/pcx/test-bpp1.pcx");
     defer file.close();
 
     var fileInStream = file.inStream();
     var fileSeekStream = file.seekableStream();
 
     var pcxFile = pcx.PCX{};
-    const pixels = try pcxFile.read(testing.allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream));
-    defer pixels.deinit(testing.allocator);
+
+    var pixelsOpt: ?color.ColorStorage = null;
+    try pcxFile.read(zigimg_test_allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream), &pixelsOpt);
+
+    defer {
+        if (pixelsOpt) |pixels| {
+            pixels.deinit(zigimg_test_allocator);
+        }
+    }
 
     expectEq(pcxFile.width, 27);
     expectEq(pcxFile.height, 27);
     expectEq(pcxFile.pixel_format, PixelFormat.Bpp1);
 
-    testing.expect(pixels == .Bpp1);
+    testing.expect(pixelsOpt != null);
 
-    expectEq(pixels.Bpp1.indices[0], 0);
-    expectEq(pixels.Bpp1.indices[15], 1);
-    expectEq(pixels.Bpp1.indices[18], 1);
-    expectEq(pixels.Bpp1.indices[19], 1);
-    expectEq(pixels.Bpp1.indices[20], 1);
-    expectEq(pixels.Bpp1.indices[22 * 27 + 11], 1);
+    if (pixelsOpt) |pixels| {
+        testing.expect(pixels == .Bpp1);
 
-    expectEq(pixels.Bpp1.palette[0].R, 102);
-    expectEq(pixels.Bpp1.palette[0].G, 90);
-    expectEq(pixels.Bpp1.palette[0].B, 155);
+        expectEq(pixels.Bpp1.indices[0], 0);
+        expectEq(pixels.Bpp1.indices[15], 1);
+        expectEq(pixels.Bpp1.indices[18], 1);
+        expectEq(pixels.Bpp1.indices[19], 1);
+        expectEq(pixels.Bpp1.indices[20], 1);
+        expectEq(pixels.Bpp1.indices[22 * 27 + 11], 1);
 
-    expectEq(pixels.Bpp1.palette[1].R, 115);
-    expectEq(pixels.Bpp1.palette[1].G, 137);
-    expectEq(pixels.Bpp1.palette[1].B, 106);
+        const palette0 = pixels.Bpp1.palette[0].toIntegerColor8();
+
+        expectEq(palette0.R, 102);
+        expectEq(palette0.G, 90);
+        expectEq(palette0.B, 155);
+
+        const palette1 = pixels.Bpp1.palette[1].toIntegerColor8();
+
+        expectEq(palette1.R, 115);
+        expectEq(palette1.G, 137);
+        expectEq(palette1.B, 106);
+    }
 }
 
 test "PCX bpp4 (linear)" {
-    const file = try testOpenFile(testing.allocator, "tests/fixtures/pcx/test-bpp4.pcx");
+    const file = try testOpenFile(zigimg_test_allocator, "tests/fixtures/pcx/test-bpp4.pcx");
     defer file.close();
 
     var fileInStream = file.inStream();
     var fileSeekStream = file.seekableStream();
 
     var pcxFile = pcx.PCX{};
-    const pixels = try pcxFile.read(testing.allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream));
-    defer pixels.deinit(testing.allocator);
+
+    var pixelsOpt: ?color.ColorStorage = null;
+    try pcxFile.read(zigimg_test_allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream), &pixelsOpt);
+
+    defer {
+        if (pixelsOpt) |pixels| {
+            pixels.deinit(zigimg_test_allocator);
+        }
+    }
 
     expectEq(pcxFile.width, 27);
     expectEq(pcxFile.height, 27);
     expectEq(pcxFile.pixel_format, PixelFormat.Bpp4);
 
-    testing.expect(pixels == .Bpp4);
+    testing.expect(pixelsOpt != null);
 
-    expectEq(pixels.Bpp4.indices[0], 1);
-    expectEq(pixels.Bpp4.indices[1], 9);
-    expectEq(pixels.Bpp4.indices[2], 0);
-    expectEq(pixels.Bpp4.indices[3], 0);
-    expectEq(pixels.Bpp4.indices[4], 4);
-    expectEq(pixels.Bpp4.indices[14 * 27 + 9], 6);
-    expectEq(pixels.Bpp4.indices[25 * 27 + 25], 7);
+    if (pixelsOpt) |pixels| {
+        testing.expect(pixels == .Bpp4);
 
-    expectEq(pixels.Bpp4.palette[0].R, 0x5e);
-    expectEq(pixels.Bpp4.palette[0].G, 0x37);
-    expectEq(pixels.Bpp4.palette[0].B, 0x97);
+        expectEq(pixels.Bpp4.indices[0], 1);
+        expectEq(pixels.Bpp4.indices[1], 9);
+        expectEq(pixels.Bpp4.indices[2], 0);
+        expectEq(pixels.Bpp4.indices[3], 0);
+        expectEq(pixels.Bpp4.indices[4], 4);
+        expectEq(pixels.Bpp4.indices[14 * 27 + 9], 6);
+        expectEq(pixels.Bpp4.indices[25 * 27 + 25], 7);
 
-    expectEq(pixels.Bpp4.palette[15].R, 0x60);
-    expectEq(pixels.Bpp4.palette[15].G, 0xb5);
-    expectEq(pixels.Bpp4.palette[15].B, 0x68);
+        const palette0 = pixels.Bpp4.palette[0].toIntegerColor8();
+
+        expectEq(palette0.R, 0x5e);
+        expectEq(palette0.G, 0x37);
+        expectEq(palette0.B, 0x97);
+
+        const palette15 = pixels.Bpp4.palette[15].toIntegerColor8();
+
+        expectEq(palette15.R, 0x60);
+        expectEq(palette15.G, 0xb5);
+        expectEq(palette15.B, 0x68);
+    }
 }
 
 test "PCX bpp8 (linear)" {
-    const file = try testOpenFile(testing.allocator, "tests/fixtures/pcx/test-bpp8.pcx");
+    const file = try testOpenFile(zigimg_test_allocator, "tests/fixtures/pcx/test-bpp8.pcx");
     defer file.close();
 
     var fileInStream = file.inStream();
     var fileSeekStream = file.seekableStream();
 
     var pcxFile = pcx.PCX{};
-    const pixels = try pcxFile.read(testing.allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream));
-    defer pixels.deinit(testing.allocator);
+
+    var pixelsOpt: ?color.ColorStorage = null;
+    try pcxFile.read(zigimg_test_allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream), &pixelsOpt);
+
+    defer {
+        if (pixelsOpt) |pixels| {
+            pixels.deinit(zigimg_test_allocator);
+        }
+    }
 
     expectEq(pcxFile.width, 27);
     expectEq(pcxFile.height, 27);
     expectEq(pcxFile.pixel_format, PixelFormat.Bpp8);
 
-    testing.expect(pixels == .Bpp8);
+    testing.expect(pixelsOpt != null);
 
-    expectEq(pixels.Bpp8.indices[0], 37);
-    expectEq(pixels.Bpp8.indices[3 * 27 + 15], 60);
-    expectEq(pixels.Bpp8.indices[26 * 27 + 26], 254);
+    if (pixelsOpt) |pixels| {
+        testing.expect(pixels == .Bpp8);
 
-    expectEq(pixels.Bpp8.palette[0].R, 0x46);
-    expectEq(pixels.Bpp8.palette[0].G, 0x1c);
-    expectEq(pixels.Bpp8.palette[0].B, 0x71);
+        expectEq(pixels.Bpp8.indices[0], 37);
+        expectEq(pixels.Bpp8.indices[3 * 27 + 15], 60);
+        expectEq(pixels.Bpp8.indices[26 * 27 + 26], 254);
 
-    expectEq(pixels.Bpp8.palette[15].R, 0x41);
-    expectEq(pixels.Bpp8.palette[15].G, 0x49);
-    expectEq(pixels.Bpp8.palette[15].B, 0x30);
+        const palette0 = pixels.Bpp8.palette[0].toIntegerColor8();
 
-    expectEq(pixels.Bpp8.palette[219].R, 0x61);
-    expectEq(pixels.Bpp8.palette[219].G, 0x8e);
-    expectEq(pixels.Bpp8.palette[219].B, 0xc3);
+        expectEq(palette0.R, 0x46);
+        expectEq(palette0.G, 0x1c);
+        expectEq(palette0.B, 0x71);
+
+        const palette15 = pixels.Bpp8.palette[15].toIntegerColor8();
+
+        expectEq(palette15.R, 0x41);
+        expectEq(palette15.G, 0x49);
+        expectEq(palette15.B, 0x30);
+
+        const palette219 = pixels.Bpp8.palette[219].toIntegerColor8();
+
+        expectEq(palette219.R, 0x61);
+        expectEq(palette219.G, 0x8e);
+        expectEq(palette219.B, 0xc3);
+    }
 }
 
 test "PCX bpp24 (planar)" {
-    const file = try testOpenFile(testing.allocator, "tests/fixtures/pcx/test-bpp24.pcx");
+    const file = try testOpenFile(zigimg_test_allocator, "tests/fixtures/pcx/test-bpp24.pcx");
     defer file.close();
 
     var fileInStream = file.inStream();
     var fileSeekStream = file.seekableStream();
 
     var pcxFile = pcx.PCX{};
-    const pixels = try pcxFile.read(testing.allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream));
-    defer pixels.deinit(testing.allocator);
+
+    var pixelsOpt: ?color.ColorStorage = null;
+    try pcxFile.read(zigimg_test_allocator, @ptrCast(*ImageInStream, &fileInStream.stream), @ptrCast(*ImageSeekStream, &fileSeekStream.stream), &pixelsOpt);
+
+    defer {
+        if (pixelsOpt) |pixels| {
+            pixels.deinit(zigimg_test_allocator);
+        }
+    }
 
     expectEq(pcxFile.header.planes, 3);
     expectEq(pcxFile.header.bpp, 8);
@@ -129,25 +183,29 @@ test "PCX bpp24 (planar)" {
     expectEq(pcxFile.height, 27);
     expectEq(pcxFile.pixel_format, PixelFormat.Rgb24);
 
-    testing.expect(pixels == .Rgb24);
+    testing.expect(pixelsOpt != null);
 
-    expectEq(pixels.Rgb24[0].R, 0x34);
-    expectEq(pixels.Rgb24[0].G, 0x53);
-    expectEq(pixels.Rgb24[0].B, 0x9f);
+    if (pixelsOpt) |pixels| {
+        testing.expect(pixels == .Rgb24);
 
-    expectEq(pixels.Rgb24[1].R, 0x32);
-    expectEq(pixels.Rgb24[1].G, 0x5b);
-    expectEq(pixels.Rgb24[1].B, 0x96);
+        expectEq(pixels.Rgb24[0].R, 0x34);
+        expectEq(pixels.Rgb24[0].G, 0x53);
+        expectEq(pixels.Rgb24[0].B, 0x9f);
 
-    expectEq(pixels.Rgb24[26].R, 0xa8);
-    expectEq(pixels.Rgb24[26].G, 0x5a);
-    expectEq(pixels.Rgb24[26].B, 0x78);
+        expectEq(pixels.Rgb24[1].R, 0x32);
+        expectEq(pixels.Rgb24[1].G, 0x5b);
+        expectEq(pixels.Rgb24[1].B, 0x96);
 
-    expectEq(pixels.Rgb24[27].R, 0x2e);
-    expectEq(pixels.Rgb24[27].G, 0x54);
-    expectEq(pixels.Rgb24[27].B, 0x99);
+        expectEq(pixels.Rgb24[26].R, 0xa8);
+        expectEq(pixels.Rgb24[26].G, 0x5a);
+        expectEq(pixels.Rgb24[26].B, 0x78);
 
-    expectEq(pixels.Rgb24[26 * 27 + 26].R, 0x88);
-    expectEq(pixels.Rgb24[26 * 27 + 26].G, 0xb7);
-    expectEq(pixels.Rgb24[26 * 27 + 26].B, 0x55);
+        expectEq(pixels.Rgb24[27].R, 0x2e);
+        expectEq(pixels.Rgb24[27].G, 0x54);
+        expectEq(pixels.Rgb24[27].B, 0x99);
+
+        expectEq(pixels.Rgb24[26 * 27 + 26].R, 0x88);
+        expectEq(pixels.Rgb24[26 * 27 + 26].G, 0xb7);
+        expectEq(pixels.Rgb24[26 * 27 + 26].B, 0x55);
+    }
 }


### PR DESCRIPTION
* Allocate Palette on the heap because the static size is too big
* readForImage now accept a *?color.ColorSurface to reduce copying
* Added IntegerColor8 and IntegerColor16 when we need 8-bit or 16-bit Integer color

Closes #37