### PR TITLE
update to latest zig I/O stream changes

### DIFF
--- a/src/format_interface.zig
+++ b/src/format_interface.zig
@@ -8,6 +8,6 @@ pub const FormatInterface = struct {
     readForImage: ReadForImageFn,
 
     pub const FormatFn = fn () image.ImageFormat;
-    pub const FormatDetectFn = fn (inStream: *image.ImageInStream, seekStream: *image.ImageSeekStream) anyerror!bool;
-    pub const ReadForImageFn = fn (allocator: *Allocator, inStream: *image.ImageInStream, seekStream: *image.ImageSeekStream, pixels: *?color.ColorStorage) anyerror!image.ImageInfo;
+    pub const FormatDetectFn = fn (inStream: image.ImageInStream, seekStream: image.ImageSeekStream) anyerror!bool;
+    pub const ReadForImageFn = fn (allocator: *Allocator, inStream: image.ImageInStream, seekStream: image.ImageSeekStream, pixels: *?color.ColorStorage) anyerror!image.ImageInfo;
 };

--- a/src/formats/bmp.zig
+++ b/src/formats/bmp.zig
@@ -160,7 +160,7 @@ pub const Bitmap = struct {
         return ImageFormat.Bmp;
     }
 
-    pub fn formatDetect(inStream: *ImageInStream, seekStream: *ImageSeekStream) !bool {
+    pub fn formatDetect(inStream: ImageInStream, seekStream: ImageSeekStream) !bool {
         var magicNumberBuffer: [2]u8 = undefined;
         _ = try inStream.read(magicNumberBuffer[0..]);
         if (std.mem.eql(u8, magicNumberBuffer[0..], BitmapMagicHeader[0..])) {
@@ -170,7 +170,7 @@ pub const Bitmap = struct {
         return false;
     }
 
-    pub fn readForImage(allocator: *Allocator, inStream: *ImageInStream, seekStream: *ImageSeekStream, pixels: *?color.ColorStorage) !ImageInfo {
+    pub fn readForImage(allocator: *Allocator, inStream: ImageInStream, seekStream: ImageSeekStream, pixels: *?color.ColorStorage) !ImageInfo {
         var bmp = Self{};
 
         try bmp.read(allocator, inStream, seekStream, pixels);
@@ -210,7 +210,7 @@ pub const Bitmap = struct {
         };
     }
 
-    pub fn read(self: *Self, allocator: *Allocator, inStream: *ImageInStream, seekStream: *ImageSeekStream, pixelsOpt: *?color.ColorStorage) !void {
+    pub fn read(self: *Self, allocator: *Allocator, inStream: ImageInStream, seekStream: ImageSeekStream, pixelsOpt: *?color.ColorStorage) !void {
         // Read file header
         self.fileHeader = try readStructLittle(inStream, BitmapFileHeader);
         if (!mem.eql(u8, self.fileHeader.magicHeader[0..], BitmapMagicHeader[0..])) {
@@ -268,7 +268,7 @@ pub const Bitmap = struct {
         }
     }
 
-    fn readPixels(inStream: *ImageInStream, pixelWidth: i32, pixelHeight: i32, pixelFormat: PixelFormat, pixels: *color.ColorStorage) !void {
+    fn readPixels(inStream: ImageInStream, pixelWidth: i32, pixelHeight: i32, pixelFormat: PixelFormat, pixels: *color.ColorStorage) !void {
         return switch (pixelFormat) {
             PixelFormat.Rgb24 => {
                 return readPixelsInternal(pixels.Rgb24, inStream, pixelWidth, pixelHeight);
@@ -282,7 +282,7 @@ pub const Bitmap = struct {
         };
     }
 
-    fn readPixelsInternal(pixels: var, inStream: *ImageInStream, pixelWidth: i32, pixelHeight: i32) !void {
+    fn readPixelsInternal(pixels: var, inStream: ImageInStream, pixelWidth: i32, pixelHeight: i32) !void {
         const ColorBufferType = @typeInfo(@TypeOf(pixels)).Pointer.child;
 
         var x: i32 = 0;

--- a/src/formats/pcx.zig
+++ b/src/formats/pcx.zig
@@ -46,10 +46,10 @@ const RLEDecoder = struct {
         remaining: usize,
     };
 
-    stream: *ImageInStream,
+    stream: ImageInStream,
     currentRun: ?Run,
 
-    fn init(stream: *ImageInStream) RLEDecoder {
+    fn init(stream: ImageInStream) RLEDecoder {
         return RLEDecoder{
             .stream = stream,
             .currentRun = null,
@@ -114,7 +114,7 @@ pub const PCX = struct {
         return ImageFormat.Pcx;
     }
 
-    pub fn formatDetect(inStream: *ImageInStream, seekStream: *ImageSeekStream) !bool {
+    pub fn formatDetect(inStream: ImageInStream, seekStream: ImageSeekStream) !bool {
         var magicNumberBuffer: [2]u8 = undefined;
         _ = try inStream.read(magicNumberBuffer[0..]);
 
@@ -129,7 +129,7 @@ pub const PCX = struct {
         return true;
     }
 
-    pub fn readForImage(allocator: *Allocator, inStream: *ImageInStream, seekStream: *ImageSeekStream, pixels: *?color.ColorStorage) !ImageInfo {
+    pub fn readForImage(allocator: *Allocator, inStream: ImageInStream, seekStream: ImageSeekStream, pixels: *?color.ColorStorage) !ImageInfo {
         var pcx = PCX{};
 
         try pcx.read(allocator, inStream, seekStream, pixels);
@@ -142,7 +142,7 @@ pub const PCX = struct {
         return imageInfo;
     }
 
-    pub fn read(self: *Self, allocator: *Allocator, inStream: *ImageInStream, seekStream: *ImageSeekStream, pixelsOpt: *?color.ColorStorage) !void {
+    pub fn read(self: *Self, allocator: *Allocator, inStream: ImageInStream, seekStream: ImageSeekStream, pixelsOpt: *?color.ColorStorage) !void {
         self.header = try utils.readStructLittle(inStream, PCXHeader);
         _ = try inStream.read(PCXHeader.padding[0..]);
 

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -27,11 +27,11 @@ pub const toMagicNumberLittle = switch (builtin.endian) {
     builtin.Endian.Big => toMagicNumberForeign,
 };
 
-pub fn readStructNative(inStream: *io.InStream(anyerror), comptime T: type) !T {
+pub fn readStructNative(inStream: io.StreamSource.InStream, comptime T: type) !T {
     return try inStream.readStruct(T);
 }
 
-pub fn readStructForeign(inStream: *io.InStream(anyerror), comptime T: type) !T {
+pub fn readStructForeign(inStream: io.StreamSource.InStream, comptime T: type) !T {
     comptime assert(@typeInfo(T).Struct.layout != builtin.TypeInfo.ContainerLayout.Auto);
 
     var result: T = undefined;


### PR DESCRIPTION
This is to help when https://github.com/ziglang/zig/pull/4710 is merged. The thing with `@ptrCast` and anyerror generic types was exploiting undefined behavior (I know you copied the pattern from the std lib, and that had to be changed too).

The diff for GBA is 

```diff
--- a/GBA/assetconverter/image_converter.zig
+++ b/GBA/assetconverter/image_converter.zig
@@ -51,8 +51,7 @@ pub const ImageConverter = struct {
         var paletteFile = try openWriteFile(targetPaletteFilePath);
         defer paletteFile.close();
 
-        var paletteOut = paletteFile.outStream();
-        var paletteOutStream = &paletteOut.stream;
+        var paletteOutStream = paletteFile.outStream();
 
         // Write palette file
         var paletteCount: usize = 0;
@@ -73,8 +72,7 @@ pub const ImageConverter = struct {
             var imageFile = try openWriteFile(convertInfo.imageInfo.target);
             defer imageFile.close();
 
-            var imageOut = imageFile.outStream();
-            var imageOutStream = &imageOut.stream;
+            var imageOutStream = imageFile.outStream();
 
             // Write image file
             var pixelCount: usize = 0;
```

with these 2 things, `zig build` completes successfully for me on ZigGBA.