### PR TITLE
Fix version of zig referenced in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a work in progress library to create, process, read and write different 
 
 ## Build
 
-This project assume current Zig master (0.5.0+378bf1c3b). 
+This project assume current Zig master (0.5.0+11df0d0cf). 
 
 Build tests
 ```


### PR DESCRIPTION
I don't have easy access to LLVM 10 yet, so I'm not actually on zig's master branch today, but the version of zig referenced in this readme doesn't build with `zig build test`. I used the timestamp of your commits here to guess a version of zig that would work.